### PR TITLE
Using sed to remove release-v

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -63,7 +63,7 @@ function translateDockerTag() {
   elif isOnMaster; then
     TAG="latest"
   elif isGitTag && uses "${INPUT_TAG_NAMES}"; then
-    TAG=$(echo ${GITHUB_REF} | sed -e "s/refs\/tags\///g")
+    TAG=$(echo ${GITHUB_REF} | sed -e "s/refs\/tags\///g" | sed -e "s/release-v//g")
   elif isGitTag; then
     TAG="latest"
   elif isPullRequest; then


### PR DESCRIPTION
Some CI using tag `release-vX.X.X` to recognize the real release in Github, but build with tag `X.X.X`, just like `Aliyun`.

And maybe we can get prefix from input in order to fit different prefix requirement.