### PR TITLE
Add note about GitHub Registry path format

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ All `buildargs` will be masked, so that they don't appear in the logs.
 
 ### cache
 Use `cache` when you have big images, that you would only like to build partially (changed layers).  
-> CAUTION: This will cache the non changed parts forever. If you use this option, make sure that these parts will be updated by another job!
+> CAUTION: Docker builds cache non-repoducable commands such as installing packages. If you use this option, your packages will never update. To avoid this, run this action on a schedule with caching **disabled** to rebuild the cache periodically.
 
 ```yaml
 with:

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ All `buildargs` will be masked, so that they don't appear in the logs.
 
 ### cache
 Use `cache` when you have big images, that you would only like to build partially (changed layers).  
-> CAUTION: Docker builds cache non-repoducable commands such as installing packages. If you use this option, your packages will never update. To avoid this, run this action on a schedule with caching **disabled** to rebuild the cache periodically.
+> CAUTION: Docker builds will cache non-repoducable commands, such as installing packages. If you use this option, your packages will never update. To avoid this, run this action on a schedule with caching **disabled** to rebuild the cache periodically.
 
 ```yaml
 with:

--- a/README.md
+++ b/README.md
@@ -41,11 +41,12 @@ jobs:
 ## Optional Arguments
 
 ### registry
-Use `registry` for pushing to a custom registry
+Use `registry` for pushing to a custom registry.
+> NOTE: GitHub's Docker registry uses a different path format to Docker Hub, as shown below.
 
 ```yaml
 with:
-  name: myDocker/repository
+  name: owner/repository/image
   username: ${{ secrets.DOCKER_USERNAME }}
   password: ${{ secrets.DOCKER_PASSWORD }}
   registry: docker.pkg.github.com


### PR DESCRIPTION
The GitHub docker registry uses a different path format to Docker Hub and others, which is worth noting.