### PR TITLE
Add example of conditional cache expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,32 @@ with:
   cache: true
 ```
 
+You can use [GitHub Actions Expression Syntax](https://help.github.com/en/github/automating-your-workflow-with-github-actions/contexts-and-expression-syntax-for-github-actions) to determine whether or not to use cache depending on the action context. For example, you can use the cache on pushes for faster builds, while also having a scheduled full build to rebuild the cache periodically:
+
+```yaml
+name: Publish Docker
+on:
+  push:
+    branches:
+      - master
+  schedule:
+    # Weekly on Sundays at 02:00
+    - cron: '0 2 * * 0'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: myDocker/repository
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        # Cache everything except scheduled builds
+        cache: github.event_name != 'schedule'
+```
+
 ### tag_names
 Use `tag_names` when you want to push tags/release by their git name (e.g. `refs/tags/MY_TAG_NAME`).  
 > CAUTION: Images produced by this feature can be override by branches with the same name - without a way to restore.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ All `buildargs` will be masked, so that they don't appear in the logs.
 
 ### cache
 Use `cache` when you have big images, that you would only like to build partially (changed layers).  
-> CAUTION: This will cache the non changed parts forever. If you use this option, make sure that these parts will be updated by another job!
+> CAUTION: Docker builds cache non-repoducable commands such as installing packages. If you use this option, your packages will never update. To avoid this, run this action on a schedule with caching **disabled** to rebuild the cache periodically.
 
 ```yaml
 with:

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ All `buildargs` will be masked, so that they don't appear in the logs.
 
 ### cache
 Use `cache` when you have big images, that you would only like to build partially (changed layers).  
-> CAUTION: Docker builds cache non-repoducable commands such as installing packages. If you use this option, your packages will never update. To avoid this, run this action on a schedule with caching **disabled** to rebuild the cache periodically.
+> CAUTION: Docker builds will cache non-repoducable commands, such as installing packages. If you use this option, your packages will never update. To avoid this, run this action on a schedule with caching **disabled** to rebuild the cache periodically.
 
 ```yaml
 with:


### PR DESCRIPTION
We can use a GitHub Actions Expression to set whether or not to use caching based on the action context. This allows a single workflow file to both use and rebuild the cache.