### PR TITLE
Add support for pushing to GCR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
-FROM docker:19.03.2 as runtime
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:alpine as runtime
 LABEL "repository"="https://github.com/elgohr/Publish-Docker-Github-Action"
 LABEL "maintainer"="Lars Gohr"
-
-RUN apk update \
-  && apk upgrade \
-  && apk add --no-cache git
 
 ADD entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]

--- a/action.yml
+++ b/action.yml
@@ -10,10 +10,10 @@ inputs:
     required: true
   username:
     description: 'The login username for the registry'
-    required: true
+    required: false
   password:
     description: 'The login password for the registry'
-    required: true
+    required: false
   registry:
     description: 'Use registry for pushing to a custom registry'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,8 +5,6 @@ function main() {
   echo "" # see https://github.com/actions/toolkit/issues/168
 
   sanitize "${INPUT_NAME}" "name"
-  sanitize "${INPUT_USERNAME}" "username"
-  sanitize "${INPUT_PASSWORD}" "password"
 
   REGISTRY_NO_PROTOCOL=$(echo "${INPUT_REGISTRY}" | sed -e 's/^https:\/\///g')
   if uses "${INPUT_REGISTRY}" && ! isPartOfTheName "${REGISTRY_NO_PROTOCOL}"; then
@@ -20,7 +18,11 @@ function main() {
     changeWorkingDirectory
   fi
 
-  echo ${INPUT_PASSWORD} | docker login -u ${INPUT_USERNAME} --password-stdin ${INPUT_REGISTRY}
+  if uses "${INPUT_USERNAME}" || uses "${INPUT_PASSWORD}"; then
+    sanitize "${INPUT_USERNAME}" "username"
+    sanitize "${INPUT_PASSWORD}" "password"
+    echo ${INPUT_PASSWORD} | docker login -u ${INPUT_USERNAME} --password-stdin ${INPUT_REGISTRY}
+  fi
 
   BUILDPARAMS=""
 


### PR DESCRIPTION
We do this by the following:

* Username and password are no longer mandatory
* Use cloud-sdk as a Dockerfile base. This is (almost) the same as the
original Alpine image, with the difference that we also have `gcloud`
installed.

This allows us to have a workflow (together with [actions/gcloud](https://github.com/actions/gcloud)) similar to below:

 ```yaml
      - name: Setup Google Cloud
        uses: actions/gcloud/auth@master
        env:
          GCLOUD_AUTH: ${{ secrets.GCLOUD_AUTH }}
      - name: Get Docker credentials
        uses: actions/gcloud/cli@master
        with:
          args: auth configure-docker
      - name: Publish to GCR
        uses: elgohr/Publish-Docker-Github-Action@master
        with:
          registry: gcr.io
          name: my-gcp-project/my-image
```

