### PR TITLE
Add second trigger to conditional cache example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ Use `cache` when you have big images, that you would only like to build partiall
 ```yaml
 name: Publish to Registry
 on:
+  push:
+    branches:
+      - master
   schedule:
     - cron: '0 2 * * 0' # Weekly on Sundays at 02:00
 jobs:


### PR DESCRIPTION
Minor touch-up. For clarity's sake, add a second trigger that will use cache, where scheduled builds don't.