### PR TITLE
Option to disable push action and only build

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,27 @@ jobs:
         cache: ${{ github.event_name != 'schedule' }}
 ```
 
+### nopush
+Use `nopush` when you only want to build the docker image without publishing it.
+This can be useful for example on pull request, where you only want to publish
+on the `master` branch for example but still want to build on Pull Requests.
+
+```yaml
+name: Publish to Registry
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: myDocker/repository
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        nopush: ${{ github.ref != 'master' }}
+```
+
 ### tag_names
 > DEPRECATED: Please use tags instead. This option will be removed in a future release.
 

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,9 @@ inputs:
   tag_names:
     description: 'Use tag_names when you want to push tags/release by their git name'
     required: false
+  nopush:
+    description: 'Disable the push action, so pull requests can only build for example. Default: false'
+    require: false
 outputs:
   tag:
     description: 'Is the tag, which was pushed'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -145,6 +145,11 @@ function push() {
   done
   docker build ${INPUT_BUILDOPTIONS} ${BUILDPARAMS} ${BUILD_TAGS} ${CONTEXT}
 
+  if usesBoolean "${INPUT_NOPUSH}"; then
+    echo "push disable by 'nopush' value";
+    return
+  fi
+
   for TAG in ${TAGS}
   do
     docker push "${INPUT_NAME}:${TAG}"


### PR DESCRIPTION
This can be useful for example on pull request, where you only want to publish
on the `master` branch for example but still want to build on Pull Requests.