### PR TITLE
Add semver support when using pushing git tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,3 +187,16 @@ with:
   password: ${{ secrets.DOCKER_PASSWORD }}
   tag_names: true
 ```
+
+### tag_semver
+Use `tag_semver` when you want to push tags using the semver syntax by their git name (e.g. `refs/tags/v1.2.3`). This will push four
+docker tags: `1.2.3`, `1.2`, `1` and `latest`. A prefix 'v' will automatically be removed.
+> CAUTION: Images produced by this feature can be override by branches with the same name - without a way to restore.
+
+```yaml
+with:
+  name: myDocker/repository
+  username: ${{ secrets.DOCKER_USERNAME }}
+  password: ${{ secrets.DOCKER_PASSWORD }}
+  tag_semver: true
+```

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ with:
 
 ### tag_semver
 Use `tag_semver` when you want to push tags using the semver syntax by their git name (e.g. `refs/tags/v1.2.3`). This will push four
-docker tags: `1.2.3`, `1.2`, `1` and `latest`. A prefix 'v' will automatically be removed.
+docker tags: `1.2.3`, `1.2` and `1`. A prefix 'v' will automatically be removed.
 > CAUTION: Images produced by this feature can be override by branches with the same name - without a way to restore.
 
 ```yaml

--- a/action.yml
+++ b/action.yml
@@ -35,6 +35,9 @@ inputs:
   tag_names:
     description: 'Use tag_names when you want to push tags/release by their git name'
     required: false
+  tag_semver:
+    description: 'Push semver docker tags. e.g. image:1.2.3, image:1.2, image:1'
+    required: false
 outputs:
   tag:
     description: 'Is the tag, which was pushed'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,6 +75,8 @@ function translateDockerTag() {
     TAGS="latest"
   elif isGitTag && usesBoolean "${INPUT_TAG_NAMES}"; then
     TAGS=$(echo ${GITHUB_REF} | sed -e "s/refs\/tags\///g")
+  elif isGitTag && usesBoolean "${INPUT_TAG_SEMVER}" && isSemver "${GITHUB_REF}"; then
+    TAGS=$(echo ${GITHUB_REF} | sed -e "s/refs\/tags\///g" | sed -E "s/v?([0-9]+)\.([0-9+])\.([0-9]+)/\1.\2.\3 \1.\2 \1/g")
   elif isGitTag; then
     TAGS="latest"
   elif isPullRequest; then
@@ -127,6 +129,10 @@ function uses() {
 
 function usesBoolean() {
   [ ! -z "${1}" ] && [ "${1}" = "true" ]
+}
+
+function isSemver() {
+  echo "${1}" | grep -Eq '^refs/tags/v?([0-9]+)\.([0-9+])\.([0-9]+)$'
 }
 
 function useSnapshot() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -73,10 +73,10 @@ function translateDockerTag() {
     INPUT_NAME=$(echo ${INPUT_NAME} | cut -d':' -f1)
   elif isOnMaster; then
     TAGS="latest"
-  elif isGitTag && usesBoolean "${INPUT_TAG_NAMES}"; then
-    TAGS=$(echo ${GITHUB_REF} | sed -e "s/refs\/tags\///g")
   elif isGitTag && usesBoolean "${INPUT_TAG_SEMVER}" && isSemver "${GITHUB_REF}"; then
     TAGS=$(echo ${GITHUB_REF} | sed -e "s/refs\/tags\///g" | sed -E "s/v?([0-9]+)\.([0-9+])\.([0-9]+)/\1.\2.\3 \1.\2 \1/g")
+  elif isGitTag && usesBoolean "${INPUT_TAG_NAMES}"; then
+    TAGS=$(echo ${GITHUB_REF} | sed -e "s/refs\/tags\///g")
   elif isGitTag; then
     TAGS="latest"
   elif isPullRequest; then


### PR DESCRIPTION
I love this GitHub Action but I was missing semver support where Docker images would be pushed with multiple version tags. When pushing a git tag `v1.2.3` this change will push images with the `1.2.3`, `1.2` and `1` tags to the Docker registry. The v prefix is optional and wil NOT be pushed.