### PR TITLE
Release version tags to Docker Hub

### DIFF
--- a/.github/workflows/release-docker-hub.yml
+++ b/.github/workflows/release-docker-hub.yml
@@ -1,0 +1,16 @@
+name: Release to Docker Hub
+release:
+  types:
+    - created
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: lgohr/publish-docker-github-action
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: ${{ env.GITHUB_REF }}

--- a/.github/workflows/release-docker-hub.yml
+++ b/.github/workflows/release-docker-hub.yml
@@ -13,4 +13,4 @@ jobs:
         name: lgohr/publish-docker-github-action
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: ${{ env.GITHUB_REF }}
+        tag_names: true


### PR DESCRIPTION
Fixes #78 

I opted to use `tags` since that way the tag on the Docker hub will match the name of the GH release.