### PR TITLE
Automatically lowercasing registry and image name

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,7 @@ main() {
     set -x
   fi
   
+  registryToLower
   nameToLower
   
   sanitize "${INPUT_NAME}" "name"
@@ -61,6 +62,10 @@ main() {
   echo "::set-output name=digest::${DIGEST}"
 
   docker logout
+}
+
+registryToLower(){
+ INPUT_REGISTRY=$(echo ${INPUT_REGISTRY} | tr '[A-Z]' '[a-z]')
 }
 
 nameToLower(){

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,12 +10,12 @@ main() {
     set -x
   fi
   
-  registryToLower
-  nameToLower
-  
   sanitize "${INPUT_NAME}" "name"
   sanitize "${INPUT_USERNAME}" "username"
   sanitize "${INPUT_PASSWORD}" "password"
+
+  registryToLower
+  nameToLower
 
   REGISTRY_NO_PROTOCOL=$(echo "${INPUT_REGISTRY}" | sed -e 's/^https:\/\///g')
   if uses "${INPUT_REGISTRY}" && ! isPartOfTheName "${REGISTRY_NO_PROTOCOL}"; then
@@ -64,19 +64,19 @@ main() {
   docker logout
 }
 
-registryToLower(){
- INPUT_REGISTRY=$(echo ${INPUT_REGISTRY} | tr '[A-Z]' '[a-z]')
-}
-
-nameToLower(){
-  INPUT_NAME=$(echo ${INPUT_NAME} | tr '[A-Z]' '[a-z]')
-}
-
 sanitize() {
   if [ -z "${1}" ]; then
     >&2 echo "Unable to find the ${2}. Did you set with.${2}?"
     exit 1
   fi
+}
+
+registryToLower(){
+ INPUT_REGISTRY=$(echo "${INPUT_REGISTRY}" | tr '[A-Z]' '[a-z]')
+}
+
+nameToLower(){
+  INPUT_NAME=$(echo "${INPUT_NAME}" | tr '[A-Z]' '[a-z]')
 }
 
 isPartOfTheName() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,7 +64,7 @@ main() {
 }
 
 nameToLower(){
-  INPUT_NAME=$(echo INPUT_NAME | tr '[A-Z]' '[a-z]')
+  INPUT_NAME=$(echo ${INPUT_NAME} | tr '[A-Z]' '[a-z]')
 }
 
 sanitize() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,6 +10,8 @@ main() {
     set -x
   fi
   
+  nameToLower
+  
   sanitize "${INPUT_NAME}" "name"
   sanitize "${INPUT_USERNAME}" "username"
   sanitize "${INPUT_PASSWORD}" "password"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ main() {
     echo "::add-mask::${INPUT_PASSWORD}"
     set -x
   fi
-
+  
   sanitize "${INPUT_NAME}" "name"
   sanitize "${INPUT_USERNAME}" "username"
   sanitize "${INPUT_PASSWORD}" "password"
@@ -59,6 +59,10 @@ main() {
   echo "::set-output name=digest::${DIGEST}"
 
   docker logout
+}
+
+nameToLower(){
+  INPUT_NAME=$(echo INPUT_NAME | tr '[A-Z]' '[a-z]')
 }
 
 sanitize() {

--- a/test.bats
+++ b/test.bats
@@ -313,7 +313,7 @@ teardown() {
 
   run /entrypoint.sh
 
-  expectMockCalled "/usr/local/bin/docker login -u USERNAME --password-stdin my.Registry.io
+  expectMockCalled "/usr/local/bin/docker login -u USERNAME --password-stdin my.registry.io
 /usr/local/bin/docker build -t my.registry.io/my/repository:latest .
 /usr/local/bin/docker push my.registry.io/my/repository:latest
 /usr/local/bin/docker inspect --format={{index .RepoDigests 0}} my.registry.io/my/repository:latest
@@ -326,7 +326,7 @@ teardown() {
 
   run /entrypoint.sh
 
-  expectMockCalled "/usr/local/bin/docker login -u USERNAME --password-stdin my.Registry.io
+  expectMockCalled "/usr/local/bin/docker login -u USERNAME --password-stdin my.registry.io
 /usr/local/bin/docker build -t my.registry.io/my/repository:latest .
 /usr/local/bin/docker push my.registry.io/my/repository:latest
 /usr/local/bin/docker inspect --format={{index .RepoDigests 0}} my.registry.io/my/repository:latest
@@ -339,7 +339,7 @@ teardown() {
 
   run /entrypoint.sh
 
-  expectMockCalled "/usr/local/bin/docker login -u USERNAME --password-stdin https://my.Registry.io
+  expectMockCalled "/usr/local/bin/docker login -u USERNAME --password-stdin https://my.registry.io
 /usr/local/bin/docker build -t my.registry.io/my/repository:latest .
 /usr/local/bin/docker push my.registry.io/my/repository:latest
 /usr/local/bin/docker inspect --format={{index .RepoDigests 0}} my.registry.io/my/repository:latest

--- a/test.bats
+++ b/test.bats
@@ -314,9 +314,9 @@ teardown() {
   run /entrypoint.sh
 
   expectMockCalled "/usr/local/bin/docker login -u USERNAME --password-stdin my.Registry.io
-/usr/local/bin/docker build -t my.Registry.io/my/repository:latest .
-/usr/local/bin/docker push my.Registry.io/my/repository:latest
-/usr/local/bin/docker inspect --format={{index .RepoDigests 0}} my.Registry.io/my/repository:latest
+/usr/local/bin/docker build -t my.registry.io/my/repository:latest .
+/usr/local/bin/docker push my.registry.io/my/repository:latest
+/usr/local/bin/docker inspect --format={{index .RepoDigests 0}} my.registry.io/my/repository:latest
 /usr/local/bin/docker logout"
 }
 
@@ -327,9 +327,9 @@ teardown() {
   run /entrypoint.sh
 
   expectMockCalled "/usr/local/bin/docker login -u USERNAME --password-stdin my.Registry.io
-/usr/local/bin/docker build -t my.Registry.io/my/repository:latest .
-/usr/local/bin/docker push my.Registry.io/my/repository:latest
-/usr/local/bin/docker inspect --format={{index .RepoDigests 0}} my.Registry.io/my/repository:latest
+/usr/local/bin/docker build -t my.registry.io/my/repository:latest .
+/usr/local/bin/docker push my.registry.io/my/repository:latest
+/usr/local/bin/docker inspect --format={{index .RepoDigests 0}} my.registry.io/my/repository:latest
 /usr/local/bin/docker logout"
 }
 
@@ -340,9 +340,9 @@ teardown() {
   run /entrypoint.sh
 
   expectMockCalled "/usr/local/bin/docker login -u USERNAME --password-stdin https://my.Registry.io
-/usr/local/bin/docker build -t my.Registry.io/my/repository:latest .
-/usr/local/bin/docker push my.Registry.io/my/repository:latest
-/usr/local/bin/docker inspect --format={{index .RepoDigests 0}} my.Registry.io/my/repository:latest
+/usr/local/bin/docker build -t my.registry.io/my/repository:latest .
+/usr/local/bin/docker push my.registry.io/my/repository:latest
+/usr/local/bin/docker inspect --format={{index .RepoDigests 0}} my.registry.io/my/repository:latest
 /usr/local/bin/docker logout"
 }
 
@@ -571,7 +571,7 @@ teardown() {
 
   expectStdOutContains "::add-mask::USERNAME
 ::add-mask::PASSWORD
-+ sanitize my/repository name"
++ registryToLower"
 }
 
 function expectStdOutContains() {

--- a/test.bats
+++ b/test.bats
@@ -571,7 +571,7 @@ teardown() {
 
   expectStdOutContains "::add-mask::USERNAME
 ::add-mask::PASSWORD
-+ registryToLower"
++ sanitize my/repository name"
 }
 
 function expectStdOutContains() {


### PR DESCRIPTION
Added automatic lowercasing for registry and image name to support using $(github.repository) variable even if github organisation or repository has uppercase letter.
Push action otherwise fails because github forces the image tag to be all lowercase