### PR TITLE
Allow customization of master branch image name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -41,6 +41,9 @@ inputs:
   tag_semver:
     description: 'Push semver docker tags. e.g. image:1.2.3, image:1.2, image:1'
     required: false
+  master_image:
+    description: 'Name used for the image based on master branch (latest by default)'
+    required: false
 outputs:
   tag:
     description: 'Is the tag, which was pushed'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -38,6 +38,7 @@ main() {
   DOCKERNAME="${INPUT_NAME}:${FIRST_TAG}"
   BUILDPARAMS=""
   CONTEXT="."
+  MASTER_IMAGE="latest"
 
   if uses "${INPUT_DOCKERFILE}"; then
     useCustomDockerfile
@@ -53,6 +54,9 @@ main() {
   fi
   if usesBoolean "${INPUT_SNAPSHOT}"; then
     useSnapshot
+  fi
+  if uses "${INPUT_MASTER_IMAGE}"; then
+    MASTER_IMAGE="${INPUT_MASTER_IMAGE}"
   fi
 
   push


### PR DESCRIPTION
For some projects it might be confusing to have latest being master branch instead of the latest tagged docker image.

In the case of https://github.com/openethereum/openethereum for example, we want to tag master as "nightly"