### PR TITLE
Boolean argument to always include `latest` when using `tag_semver`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker:19.03.2 as runtime
-LABEL "repository"="https://github.com/elgohr/Publish-Docker-Github-Action"
+LABEL "repository"="https://github.com/Enrico2/Publish-Docker-Github-Action"
 LABEL "maintainer"="Lars Gohr"
 
 RUN apk update \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM docker:19.03.2 as runtime
-LABEL "repository"="https://github.com/Enrico2/Publish-Docker-Github-Action"
+LABEL "repository"="https://github.com/elgohr/Publish-Docker-Github-Action"
 LABEL "maintainer"="Lars Gohr"
 
 RUN apk update \

--- a/README.md
+++ b/README.md
@@ -263,7 +263,9 @@ with:
 ```
 
 #### include_latest (when using `tag_semver`)
-Always push the `latest` tag when using `tag_semver`, when you want ot push tags using `tags` or `tag_semver` as well as `latest`
+Always push the `latest` tag. This only applies when using `tag_semver`, 
+and the version doesn't contain a special component (i.e. any non-number character after the patch part)
+
 ```yaml
 with:
   name: myDocker/repository

--- a/README.md
+++ b/README.md
@@ -261,3 +261,14 @@ with:
   password: ${{ secrets.DOCKER_PASSWORD }}
   tag_semver: true
 ```
+
+#### include_latest
+Always push the `latest` tag, when you want ot push tags using `tags` or `tag_semver` as well as `latest`
+```yaml
+with:
+  name: myDocker/repository
+  username: ${{ secrets.DOCKER_USERNAME }}
+  password: ${{ secrets.DOCKER_PASSWORD }}
+  tag_semver: true
+  include_latest: true
+```

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ with:
 
 #### include_latest (when using `tag_semver`)
 Always push the `latest` tag. This only applies when using `tag_semver`, 
-and the version doesn't contain a special component (i.e. any non-number character after the patch part)
+and the version doesn't contain a pre-release component (i.e. any non-number character after the patch part)
 
 ```yaml
 with:

--- a/README.md
+++ b/README.md
@@ -262,8 +262,8 @@ with:
   tag_semver: true
 ```
 
-#### include_latest
-Always push the `latest` tag, when you want ot push tags using `tags` or `tag_semver` as well as `latest`
+#### include_latest (when using `tag_semver`)
+Always push the `latest` tag when using `tag_semver`, when you want ot push tags using `tags` or `tag_semver` as well as `latest`
 ```yaml
 with:
   name: myDocker/repository

--- a/action.yml
+++ b/action.yml
@@ -54,7 +54,7 @@ inputs:
     description: 'Set no_push to true if you want to prevent the action from pushing to a registry (default: false)'
     required: false
   include_latest:
-    description: 'Always push latest tag'
+    description: 'When tag_semver=true, also push `latest` tag for versions without a pre-release component'
     required: false
 outputs:
   tag:

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,9 @@ inputs:
   no_push:
     description: 'Set no_push to true if you want to prevent the action from pushing to a registry (default: false)'
     required: false
+  include_latest:
+    description: 'Always push latest tag'
+    required: false
 outputs:
   tag:
     description: 'Is the tag, which was pushed'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -98,18 +98,18 @@ translateDockerTag() {
   elif isOnDefaultBranch; then
     TAGS="latest"
   elif isGitTag && usesBoolean "${INPUT_TAG_SEMVER}" && isSemver "${GITHUB_REF}"; then
-    local RE='v?([0-9]+)\.([0-9]+)\.([0-9]+)(-[0-9A-Za-z-]+)?'
+    local RE='v?([0-9]+)\.([0-9]+)\.([0-9]+)(-([0-9A-Za-z\-\.]*))?'
 
     local VERSION=$(echo "${GITHUB_REF}" | sed -e "s/refs\/tags\///g")
     local MAJOR=$(echo "${VERSION}" | sed -E "s/${RE}/\1/g")
     local MINOR=$(echo "${VERSION}" | sed -E "s/${RE}/\2/g")
     local PATCH=$(echo "${VERSION}" | sed -E "s/${RE}/\3/g")
-    local SPECIAL=$(echo "${VERSION}" | sed -E "s/${RE}/\4/g")
+    local SPECIAL=$(echo "${VERSION}" | sed -E "s/${RE}/\5/g")
 
     if [ -z "$SPECIAL" ]; then
-      TAGS="$MAJOR $MAJOR.$MINOR $MAJOR.$MINOR.$PATCH"
+      TAGS="${MAJOR} ${MAJOR}.${MINOR} ${MAJOR}.${MINOR}.${PATCH}"
     else 
-      TAGS="$MAJOR.$MINOR.$PATCH$SPECIAL"
+      TAGS="$MAJOR.$MINOR.$PATCH-$SPECIAL"
     fi;
 
     if usesBoolean "${INPUT_INCLUDE_LATEST}"; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -107,7 +107,7 @@ translateDockerTag() {
     local SPECIAL=$(echo "${VERSION}" | sed -E "s/${RE}/\5/g")
 
     if [ -z "$SPECIAL" ]; then
-      TAGS="${MAJOR} ${MAJOR}.${MINOR} ${MAJOR}.${MINOR}.${PATCH}"
+      TAGS="${MAJOR}.${MINOR}.${PATCH} ${MAJOR}.${MINOR} ${MAJOR}"
     else 
       TAGS="$MAJOR.$MINOR.$PATCH-$SPECIAL"
     fi;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -103,7 +103,7 @@ translateDockerTag() {
     local VERSION=$(echo "${GITHUB_REF}" | sed -e "s/refs\/tags\///g")
     local MAJOR=$(echo "${VERSION}" | sed -E "s/${RE}/\1/g")
     local MINOR=$(echo "${VERSION}" | sed -E "s/${RE}/\2/g")
-    local MINOR=$(echo "${VERSION}" | sed -E "s/${RE}/\3/g")
+    local PATCH=$(echo "${VERSION}" | sed -E "s/${RE}/\3/g")
     local SPECIAL=$(echo "${VERSION}" | sed -E "s/${RE}/\4/g")
 
     if [ -z "$SPECIAL" ]; then

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -108,6 +108,10 @@ translateDockerTag() {
   else
     TAGS="${BRANCH}"
   fi;
+
+  if usesBoolean "${INPUT_INCLUDE_LATEST}"; then
+    TAGS="latest ${TAGS}"
+  fi;
 }
 
 hasCustomTag() {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -108,14 +108,15 @@ translateDockerTag() {
 
     if [ -z "$SPECIAL" ]; then
       TAGS="${MAJOR}.${MINOR}.${PATCH} ${MAJOR}.${MINOR} ${MAJOR}"
+
+      if usesBoolean "${INPUT_INCLUDE_LATEST}"; then
+        TAGS="${TAGS} latest"
+      fi;
+
     else 
       TAGS="$MAJOR.$MINOR.$PATCH-$SPECIAL"
     fi;
 
-    if usesBoolean "${INPUT_INCLUDE_LATEST}"; then
-      TAGS="latest ${TAGS}"
-    fi;
-    
   elif isGitTag && usesBoolean "${INPUT_TAG_NAMES}"; then
     TAGS=$(echo "${GITHUB_REF}" | sed -e "s/refs\/tags\///g")
   elif isGitTag; then

--- a/test.bats
+++ b/test.bats
@@ -161,10 +161,8 @@ teardown() {
     expectStdOutContains "::set-output name=tag::1.1.1-${SUFFIX}"
 
     expectMockCalledContains "/usr/local/bin/docker login -u USERNAME --password-stdin
-/usr/local/bin/docker build -t my/repository:1.1.1-${SUFFIX} -t my/repository:1.1-${SUFFIX} -t my/repository:1-${SUFFIX} .
+/usr/local/bin/docker build -t my/repository:1.1.1-${SUFFIX} .
 /usr/local/bin/docker push my/repository:1.1.1-${SUFFIX}
-/usr/local/bin/docker push my/repository:1.1-${SUFFIX}
-/usr/local/bin/docker push my/repository:1-${SUFFIX}
 /usr/local/bin/docker inspect --format={{index .RepoDigests 0}} my/repository:1.1.1-${SUFFIX}
 /usr/local/bin/docker logout"
   done


### PR DESCRIPTION
This PR adds a boolean input argument: `include_latest`. 
When provided as `true` **and** `tag_semver` is true **and** the tag version **does not contain** a pre-release component, then the `latest` tag is added to the list of tags built/pushed to.

We had this need, so we implemented it and used the forked version for now.
Ideally though, this would be merged upstream and we'd benefit from future maintenance.

It seems as though the need exists: https://github.com/elgohr/Publish-Docker-Github-Action/issues/70

I've tried to make this as non-intrusive as possible.

Test cases, README updates and description included.