### PR TITLE
docker image 19.03.02 stopped functioning, 19.03 is fine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:19.03.2 as runtime
+FROM docker:19.03 as runtime
 LABEL "repository"="https://github.com/elgohr/Publish-Docker-Github-Action"
 LABEL "maintainer"="Lars Gohr"
 


### PR DESCRIPTION
Here's the behavior I get without this change:

```
> docker run -it docker:19.03.2 sh
/ # apk update
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
v3.10.8-1-g5065330860 [http://dl-cdn.alpinelinux.org/alpine/v3.10/main]
v3.10.6-10-ged79a86de3 [http://dl-cdn.alpinelinux.org/alpine/v3.10/community]
OK: 10352 distinct packages available
/ # apk upgrade
Upgrading critical system libraries and apk-tools:
(1/1) Upgrading apk-tools (2.10.4-r2 -> 2.10.4-r3)
Executing busybox-1.30.1-r2.trigger
Continuing the upgrade transaction with new apk-tools:
(1/8) Upgrading musl (1.1.22-r3 -> 1.1.22-r4)
(2/8) Upgrading busybox (1.30.1-r2 -> 1.30.1-r5)
Executing busybox-1.30.1-r5.post-upgrade
(3/8) Upgrading libcrypto1.1 (1.1.1c-r0 -> 1.1.1k-r0)
(4/8) Upgrading libssl1.1 (1.1.1c-r0 -> 1.1.1k-r0)
(5/8) Upgrading ca-certificates-cacert (20190108-r0 -> 20191127-r2)
(6/8) Upgrading ssl_client (1.30.1-r2 -> 1.30.1-r5)
(7/8) Upgrading ca-certificates (20190108-r0 -> 20191127-r2)
ERROR: ca-certificates-20191127-r2: BAD archive
(8/8) Upgrading musl-utils (1.1.22-r3 -> 1.1.22-r4)
Executing busybox-1.30.1-r5.trigger
1 error; 6 MiB in 15 packages
```