### PR TITLE
Change Docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker:20.10.8 as runtime
+FROM docker:20.10.6 as runtime
 LABEL "repository"="https://github.com/elgohr/Publish-Docker-Github-Action"
 LABEL "maintainer"="Lars Gohr"
 


### PR DESCRIPTION
Docker version 20.10.8 -> 20.10.6

Bats 1.3.0-r0 is doesn't work.
have some bug
```
  /usr/bin/date: line 12: mockReturns: No such file or directory
  /usr/bin/date: line 13: /usr/bin/date: syntax error: operand expected (error token is "/usr/bin/date")
  /usr/bin/date: line 12: mockReturns: No such file or directory
  /usr/bin/date: line 13: /usr/bin/date: syntax error: operand expected (error token is "/usr/bin/date")
  /usr/libexec/bats-core/bats-exec-test: line 127: * 1000 : syntax error: operand expected (error token is "* 1000 ")
  /usr/lib/bats-core/tracing.bash: line 61: BATS_STACK_TRACE: bad array subscript
```

So I changed version of Docker because bats 1.2.1-r0 was exist in [Alpine:3.13](https://pkgs.org/download/bats)