### PR TITLE
Readme: Remove unnecessary pre from releasing with tag name

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,6 @@ Use `tags` when you want to bring your own tags (separated by comma).
     tags: "latest,another"
 ```
 
-When using dynamic tag names the environment variable must be set via echo, as variables set in the environment will not auto resolve by convention.  
 This example illustrates how you would push to latest along with creating a custom version tag in a release. Setting it to only run on published events will keep your tags from being filled with commit hashes and will only publish when a GitHub release is created, so if the GitHub release is 2.14 this will publish to the latest and 2.14 tags.
 
 ```yaml
@@ -226,13 +225,12 @@ jobs:
     steps:
     - uses: actions/checkout@master
     - name: Publish to Registry
-      pre: echo ::save-state name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: myDocker/repository
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
-        tags: "latest,${{ env.STATE_RELEASE_VERSION }}"
+        tags: "latest,${{ github.event.release.tag_name }}""
 ```
 
 #### tag_names


### PR DESCRIPTION
I've used the following method in my usage of your action (thank you for maintaining this btw!)

Was a bit cleaner to not need use the pre step imo.

I've been using the following to get latest, snapshots, and version releases

```name: Publish Docker
# Publish to docker if the Static Analysis on main completed successfully

on:
    workflow_run:
        workflows: ['Static Analysis']
        branches: [main]
        types:
            - completed

    release:
        types: [published]

jobs:
    build:
        runs-on: ubuntu-latest
        steps:
            - uses: actions/checkout@v2
            - name: debug tag_name
              run: echo ${{ github.event.release.tag_name }}
            - name: Publish to Registry
              uses: elgohr/Publish-Docker-Github-Action@master
              with:
                  name: **NAME**
                  username: ${{ secrets.DOCKER_USERNAME }}
                  password: ${{ secrets.DOCKER_PASSWORD }}
                  default_branch: main
                  snapshot: true
                  tags: "latest,${{ github.event.release.tag_name }}"
```