### PR TITLE
Use the new set output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -67,14 +67,14 @@ main() {
   fi
 
   echo "::set-output name=tag::${FIRST_TAG}"
-  echo "tag=${FIRST_TAG}" >> "$GITHUB_ENV"
+  echo "tag=${FIRST_TAG}" >> "$GITHUB_OUTPUT"
   if uses "${INPUT_PLATFORMS}"; then
     DIGEST=$(jq -r '."containerimage.digest"' metadata.json)
   else 
     DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' ${DOCKERNAME})
   fi
   echo "::set-output name=digest::${DIGEST}"
-  echo "digest=${DIGEST}" >> "$GITHUB_ENV"
+  echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
 
   docker logout
 }
@@ -185,7 +185,7 @@ useSnapshot() {
   local SNAPSHOT_TAG="${TIMESTAMP}${SHORT_SHA}"
   TAGS="${TAGS} ${SNAPSHOT_TAG}"
   echo "::set-output name=snapshot-tag::${SNAPSHOT_TAG}"
-  echo "snapshot-tag=${SNAPSHOT_TAG}" >> "$GITHUB_ENV"
+  echo "snapshot-tag=${SNAPSHOT_TAG}" >> "$GITHUB_OUTPUT"
 }
 
 build() {

--- a/test.bats
+++ b/test.bats
@@ -2,7 +2,7 @@
 
 setup(){
   export PATH="/usr/local/sbin:/usr/local/mock:/usr/sbin:/usr/bin:/sbin:/bin"
-  export GITHUB_ENV="/tmp/githubOutput"
+  export GITHUB_OUTPUT="/tmp/githubOutput"
 
   cat /dev/null >| mockArgs
   cat /dev/null >| mockStdin
@@ -19,7 +19,7 @@ setup(){
 }
 
 teardown() {
-  rm -f "${GITHUB_ENV}"
+  rm -f "${GITHUB_OUTPUT}"
   unset INPUT_TAG_NAMES
   unset INPUT_SNAPSHOT
   unset INPUT_DOCKERFILE
@@ -37,7 +37,7 @@ teardown() {
   run /entrypoint.sh
 
   expectStdOutContains "::set-output name=tag::latest"
-  expectGitHubEnvContains "tag=latest"
+  expectGitHubOutputContains "tag=latest"
 
   expectMockCalledContains "/usr/local/mock/docker login -u USERNAME --password-stdin
 /usr/local/mock/docker build -t my/repository:latest .
@@ -52,7 +52,7 @@ teardown() {
   run /entrypoint.sh
 
   expectStdOutContains "::set-output name=tag::latest"
-  expectGitHubEnvContains "tag=latest"
+  expectGitHubOutputContains "tag=latest"
 
   expectMockCalledContains "/usr/local/mock/docker login -u USERNAME --password-stdin
 /usr/local/mock/docker build -t my/repository:latest .
@@ -67,7 +67,7 @@ teardown() {
   run /entrypoint.sh
 
   expectStdOutContains "::set-output name=tag::myBranch"
-  expectGitHubEnvContains "tag=myBranch"
+  expectGitHubOutputContains "tag=myBranch"
 
   expectMockCalledContains "/usr/local/mock/docker build -t my/repository:myBranch .
 /usr/local/mock/docker push my/repository:myBranch"
@@ -79,7 +79,7 @@ teardown() {
   run /entrypoint.sh
 
   expectStdOutContains "::set-output name=tag::myBranch-withDash"
-  expectGitHubEnvContains "tag=myBranch-withDash"
+  expectGitHubOutputContains "tag=myBranch-withDash"
 
   expectMockCalledContains "/usr/local/mock/docker build -t my/repository:myBranch-withDash .
 /usr/local/mock/docker push my/repository:myBranch-withDash"
@@ -91,7 +91,7 @@ teardown() {
   run /entrypoint.sh
 
   expectStdOutContains "::set-output name=tag::latest"
-  expectGitHubEnvContains "tag=latest"
+  expectGitHubOutputContains "tag=latest"
 
   expectMockCalledContains "/usr/local/mock/docker login -u USERNAME --password-stdin
 /usr/local/mock/docker build -t my/repository:latest .
@@ -107,7 +107,7 @@ teardown() {
   run /entrypoint.sh
 
   expectStdOutContains "::set-output name=tag::myRelease"
-  expectGitHubEnvContains "tag=myRelease"
+  expectGitHubOutputContains "tag=myRelease"
 
   expectMockCalledContains "/usr/local/mock/docker build -t my/repository:myRelease .
 /usr/local/mock/docker push my/repository:myRelease"
@@ -120,7 +120,7 @@ teardown() {
   run /entrypoint.sh
 
   expectStdOutContains "::set-output name=tag::latest"
-  expectGitHubEnvContains "tag=latest"
+  expectGitHubOutputContains "tag=latest"
 
   expectMockCalledContains "/usr/local/mock/docker build -t my/repository:latest .
 /usr/local/mock/docker push my/repository:latest"
@@ -133,7 +133,7 @@ teardown() {
   run /entrypoint.sh
 
   expectStdOutContains "::set-output name=tag::1.2.3"
-  expectGitHubEnvContains "tag=1.2.3"
+  expectGitHubOutputContains "tag=1.2.3"
 
   expectMockCalledContains "/usr/local/mock/docker login -u USERNAME --password-stdin
 /usr/local/mock/docker build -t my/repository:1.2.3 -t my/repository:1.2 -t my/repository:1 .
@@ -151,7 +151,7 @@ teardown() {
   run /entrypoint.sh
 
   expectStdOutContains "::set-output name=tag::12.345.5678"
-  expectGitHubEnvContains "tag=12.345.5678"
+  expectGitHubOutputContains "tag=12.345.5678"
 
   expectMockCalledContains "/usr/local/mock/docker login -u USERNAME --password-stdin
 /usr/local/mock/docker build -t my/repository:12.345.5678 -t my/repository:12.345 -t my/repository:12 .
@@ -175,7 +175,7 @@ teardown() {
     run /entrypoint.sh
 
     expectStdOutContains "::set-output name=tag::1.1.1-${SUFFIX}"
-    expectGitHubEnvContains "tag=1.1.1-${SUFFIX}"
+    expectGitHubOutputContains "tag=1.1.1-${SUFFIX}"
 
     expectMockCalledContains "/usr/local/mock/docker login -u USERNAME --password-stdin
 /usr/local/mock/docker build -t my/repository:1.1.1-${SUFFIX} .
@@ -192,7 +192,7 @@ teardown() {
   run /entrypoint.sh
 
   expectStdOutContains "::set-output name=tag::1.2.34"
-  expectGitHubEnvContains "tag=1.2.34"
+  expectGitHubOutputContains "tag=1.2.34"
 
   expectMockCalledContains "/usr/local/mock/docker login -u USERNAME --password-stdin
 /usr/local/mock/docker build -t my/repository:1.2.34 -t my/repository:1.2 -t my/repository:1 .
@@ -210,7 +210,7 @@ teardown() {
   run /entrypoint.sh
 
   expectStdOutContains "::set-output name=tag::latest"
-  expectGitHubEnvContains "tag=latest"
+  expectGitHubOutputContains "tag=latest"
 
   expectMockCalledContains "/usr/local/mock/docker build -t my/repository:latest .
 /usr/local/mock/docker push my/repository:latest"
@@ -223,7 +223,7 @@ teardown() {
   run /entrypoint.sh
 
   expectStdOutContains "::set-output name=tag::latest"
-  expectGitHubEnvContains "tag=latest"
+  expectGitHubOutputContains "tag=latest"
 
   expectMockCalledContains "/usr/local/mock/docker build -t my/repository:latest .
 /usr/local/mock/docker push my/repository:latest"
@@ -235,7 +235,7 @@ teardown() {
   run /entrypoint.sh  export GITHUB_REF='refs/heads/master'
 
   expectStdOutContains "::set-output name=tag::latest"
-  expectGitHubEnvContains "tag=latest"
+  expectGitHubOutputContains "tag=latest"
 
   expectMockCalledContains "/usr/local/mock/docker build -f MyDockerFileName -t my/repository:latest .
 /usr/local/mock/docker push my/repository:latest"
@@ -255,7 +255,7 @@ teardown() {
   expectStdOutContains "
 ::set-output name=snapshot-tag::19700101010112169e
 ::set-output name=tag::latest"
-  expectGitHubEnvContains "snapshot-tag=19700101010112169etag=latest"
+  expectGitHubOutputContains "snapshot-tag=19700101010112169etag=latest"
 
   expectMockCalledContains "/usr/local/mock/date +%Y%m%d%H%M%S
 /usr/local/mock/docker build -t my/repository:latest -t my/repository:19700101010112169e .
@@ -276,7 +276,7 @@ teardown() {
 
   expectStdOutContains "
 ::set-output name=tag::latest"
-  expectGitHubEnvContains "tag=latest"
+  expectGitHubOutputContains "tag=latest"
 
   expectMockCalledContains "/usr/local/mock/docker build -t my/repository:latest .
 /usr/local/mock/docker push my/repository:latest"
@@ -427,7 +427,7 @@ teardown() {
 
   expectStdOutContains "
 ::set-output name=tag::12169ed809255604e557a82617264e9c373faca7"
-  expectGitHubEnvContains "tag=12169ed809255604e557a82617264e9c373faca7"
+  expectGitHubOutputContains "tag=12169ed809255604e557a82617264e9c373faca7"
 
   expectMockCalledContains "/usr/local/mock/docker build -t my/repository:12169ed809255604e557a82617264e9c373faca7 .
 /usr/local/mock/docker push my/repository:12169ed809255604e557a82617264e9c373faca7"
@@ -440,7 +440,7 @@ teardown() {
 
   expectStdOutContains "
 ::set-output name=tag::custom-tag"
-  expectGitHubEnvContains "tag=custom-tag"
+  expectGitHubOutputContains "tag=custom-tag"
 
   expectMockCalledContains "/usr/local/mock/docker build -t my/repository:custom-tag .
 /usr/local/mock/docker push my/repository:custom-tag"
@@ -455,7 +455,7 @@ teardown() {
 ::add-mask::MY_FIRST
 ::add-mask::MY_SECOND
 ::set-output name=tag::latest"
-  expectGitHubEnvContains "tag=latest"
+  expectGitHubOutputContains "tag=latest"
 
   expectMockCalledContains "/usr/local/mock/docker build --build-arg MY_FIRST --build-arg MY_SECOND -t my/repository:latest ."
 }
@@ -468,7 +468,7 @@ teardown() {
   expectStdOutContains "
 ::add-mask::MY_ONLY
 ::set-output name=tag::latest"
-  expectGitHubEnvContains "tag=latest"
+  expectGitHubOutputContains "tag=latest"
 
   expectMockCalledContains "/usr/local/mock/docker build --build-arg MY_ONLY -t my/repository:latest ."
 }
@@ -550,7 +550,7 @@ teardown() {
   run /entrypoint.sh
 
   expectStdOutContains "::set-output name=digest::my/repository@sha256:53b76152042486bc741fe59f130bfe683b883060c8284271a2586342f35dcd0e"
-  expectGitHubEnvContains "digest=my/repository@sha256:53b76152042486bc741fe59f130bfe683b883060c8284271a2586342f35dcd0e"
+  expectGitHubOutputContains "digest=my/repository@sha256:53b76152042486bc741fe59f130bfe683b883060c8284271a2586342f35dcd0e"
 
   expectMockCalledContains "/usr/local/mock/docker push my/repository:latest
 /usr/local/mock/docker inspect --format={{index .RepoDigests 0}} my/repository:latest"
@@ -662,7 +662,7 @@ teardown() {
   run /entrypoint.sh
 
   expectStdOutContains "::set-output name=tag::latest"
-  expectGitHubEnvContains "tag=latest"
+  expectGitHubOutputContains "tag=latest"
 
   expectMockCalledContains "/usr/local/mock/docker login -u USERNAME --password-stdin
 /usr/local/mock/docker build -t my/repository:latest .
@@ -716,7 +716,7 @@ EOT
   run /entrypoint.sh
 
   expectStdOutContains "::set-output name=tag::latest::set-output name=digest::sha256:aa2c7631cc1bbf588192ec7e55b428ad92fe63834200303f28e93444d7fc114a"
-  expectGitHubEnvContains "tag=latestdigest=sha256:aa2c7631cc1bbf588192ec7e55b428ad92fe63834200303f28e93444d7fc114a"
+  expectGitHubOutputContains "tag=latestdigest=sha256:aa2c7631cc1bbf588192ec7e55b428ad92fe63834200303f28e93444d7fc114a"
 
   expectMockCalledContains "/usr/local/mock/docker login -u USERNAME --password-stdin
 /usr/local/mock/docker buildx build --push --metadata-file metadata.json --platform linux/amd64,linux/arm64 -t my/repository:latest .
@@ -740,9 +740,9 @@ expectStdOutContains() {
   echo "${got}" | grep "${expected}"
 }
 
-expectGitHubEnvContains() {
+expectGitHubOutputContains() {
   local expected=$(echo "${1}" | tr -d '\n')
-  local got=$(cat "${GITHUB_ENV}" | tr -d '\n')
+  local got=$(cat "${GITHUB_OUTPUT}" | tr -d '\n')
   echo "Expected: |${expected}|
   Got: |${got}|"
   echo "${got}" | grep "${expected}"


### PR DESCRIPTION
Fix #167

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Tested: 
- With `make test`