### PR TITLE
chore: Improve Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
 - package-ecosystem: "docker"
   directory: "/"
   schedule:
-    interval: "daily" 
+    interval: "daily"
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,26 @@
 FROM ubuntu:24.04@sha256:562456a05a0dbd62a671c1854868862a4687bf979a96d48ae8e766642cd911e8 as runtime
 ENV DEBIAN_FRONTEND=noninteractive
+COPY docker/01_nodoc /etc/dpkg/dpkg.cfg.d/
 RUN apt-get update \
   && apt-get install -y ca-certificates curl gnupg lsb-release jq \
   && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
   $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null \
-  && apt-get update \
-  && apt-get install -y docker-ce docker-ce-cli containerd.io
-ADD entrypoint.sh /entrypoint.sh
+  && apt-get update -o Dir::Etc::sourcelist="sources.list.d/docker.list" \
+         -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0" \
+  && apt-get install -y docker-ce docker-ce-cli containerd.io \
+  && apt-get remove -y curl gnupg lsb-release \
+  && rm /usr/libexec/docker/cli-plugins/docker-compose \
+  && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 
-FROM runtime as testEnv
-RUN apt-get install -y coreutils bats
-ADD test.bats /test.bats
-ADD mock.sh /usr/local/mock/docker
-ADD mock.sh /usr/local/mock/date
+FROM runtime AS testEnv
+RUN apt-get install -y coreutils bats \
+  && apt-get autoremove -y && apt-get clean && rm -rf /var/lib/apt/lists/*
+COPY test.bats /test.bats
+COPY mock.sh /usr/local/mock/docker
+COPY mock.sh /usr/local/mock/date
 RUN /test.bats
 
 FROM runtime

--- a/docker/01_nodoc
+++ b/docker/01_nodoc
@@ -1,0 +1,11 @@
+# /etc/dpkg/dpkg.cfg.d/01_nodoc
+
+# Delete locales
+path-exclude=/usr/share/locale/*;
+
+# Delete man pages
+path-exclude=/usr/share/man/*;
+
+# Delete docs
+path-exclude=/usr/share/doc/*;
+path-include=/usr/share/doc/*/copyright;


### PR DESCRIPTION
Image builds faster and smaller, fixed some Dockerfile warnings and 166 security findings 😅
Please double-check if everything is still working as expected (I removed `docker-compose`) and release a new image.

Consider rebuilding the image automatically with something like https://github.com/aquasecurity/trivy-action and migrating to alpine, should be smaller and have less dependencies (`docker` also installs engine, cli and buildx).
https://pkgs.alpinelinux.org/packages?name=docker*&branch=v3.19&repo=community&arch=x86_64